### PR TITLE
Latex included - css and first md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ sample: https://www.jannikbuschke.de/gatsby-antd-docs/
 
 Forked from https://github.com/cvluca/gatsby-starter-markdown.
 
-This starter is boilerplate for (technical) documentation websites optionally accomponied by a blog (you can use it forever you want of course).
+This starter is boilerplate for (technical) documentation websites optionally accompanied by a blog (you can use it forever you want of course).
 
 # Getting started
 
@@ -26,6 +26,7 @@ Edit files in `/content/docs` and see live updates.
 - [x] Markdown
 - [x] MDX
 - [x] Syntax highlighting
+- [x] Latex
 
 # Roadmap
 

--- a/contents/docs/get-started/latex.md
+++ b/contents/docs/get-started/latex.md
@@ -1,0 +1,21 @@
+---
+title: Latex
+root: '/docs'
+parents: ['Get Started']
+---
+
+# Latex Guide
+
+Included the `gatsby-remark-katex` plugin
+
+## Examples
+
+Inline presentiation view: $a^2 + b^2 = c^2$
+
+Display mode:
+
+$$
+a^2 + b^2 = c^2
+$$
+
+The default configuration is located at the `gatsby-config` file. For additional configurations with this plugin, check out the [official docs](https://www.gatsbyjs.org/packages/gatsby-remark-katex/)

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,3 +1,4 @@
 // gatsby-browser.js
 require('prismjs/themes/prism-coy.css')
 require('antd/dist/antd.css')
+require(`katex/dist/katex.min.css`)


### PR DESCRIPTION
Completes #6 by including the css to use the `gatsby-remark-katex ` css. Also included an example in the introduction section